### PR TITLE
Feat/add flake nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ dryrun-*
 local-testbed*
 *.log.ansi
 results/
+
+flake.lock

--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@
 
 The code in this branch is a prototype of Mysticeti. It supplements the paper [Mysticeti: Low-Latency DAG Consensus with Fast Commit Path](https://arxiv.org/abs/2310.14821) enabling reproducible results. There are no plans to maintain this branch.
 
+## Development
+
+When developing, the analyzer may show errors in files. To fix this start code in a nix environment. 
+
+    nix develop
+    code .
+
+
 ## License
 
 This software is licensed as [Apache 2.0](LICENSE).

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,39 @@
+# start the nix shell and start vscode in it
+# nix develop
+# code .
+
+{
+  description = "Flake for mysticeti project";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, rust-overlay, flake-utils }:
+    flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ] (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ (import rust-overlay) ];
+        };
+        rustToolchain = pkgs.rust-bin.stable.latest.default;
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            rustToolchain
+            openssl
+            pkg-config
+            clang
+          ];
+
+          shellHook = ''
+            export RUST_BACKTRACE=1
+            export CARGO_INCREMENTAL=0
+          '';
+        };
+      }
+    );
+}


### PR DESCRIPTION
## What is this?

Introduces nix flake.

## Background

When developing locally with vscode, several files show errors due to analyzer issues. For example this addresses an error relating to `proc-macro crate build data is missing dylib path` that overwhelms the orchestrator `main.rs` file.

Nix is able to resolve this.

## Fix

Adds flake.nix. Start using


```
nix develop
code .
```